### PR TITLE
Update to expected behavior for both native and guestshell

### DIFF
--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -35,6 +35,7 @@ describe Ohai::System, "Linux plugin platform" do
   let(:have_parallels_release) { false }
   let(:have_raspi_config) { false }
   let(:have_os_release) { false }
+  let(:have_cisco_release) { false }
 
   before(:each) do
     @plugin = get_plugin("linux/platform")
@@ -53,6 +54,7 @@ describe Ohai::System, "Linux plugin platform" do
     allow(File).to receive(:exist?).with("/etc/parallels-release").and_return(have_parallels_release)
     allow(File).to receive(:exist?).with("/usr/bin/raspi-config").and_return(have_raspi_config)
     allow(File).to receive(:exist?).with("/etc/os-release").and_return(have_os_release)
+    allow(File).to receive(:exist?).with("/etc/shared/os-release").and_return(have_cisco_release)
 
     allow(File).to receive(:read).with("PLEASE STUB ALL File.read CALLS")
   end
@@ -367,6 +369,7 @@ OS_RELEASE
 
         before do
           expect(File).to receive(:read).with("/etc/redhat-release").and_return("CentOS release 7.1")
+          expect(File).to receive(:read).with("/etc/os-release").and_return(os_release_content)
         end
 
         it "correctly detects EL7" do
@@ -377,6 +380,57 @@ OS_RELEASE
 
       end
 
+      context "on Cisco 'guestshell' with /etc/os-release and overrides" do
+
+        let(:have_os_release) { true }
+
+        let(:os_release_content) do
+          <<-OS_RELEASE
+NAME="CentOS Linux"
+VERSION="7 (Core)"
+ID="centos"
+ID_LIKE="rhel fedora"
+VERSION_ID="7"
+PRETTY_NAME="CentOS Linux 7 (Core)"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:centos:centos:7"
+HOME_URL="https://www.centos.org/"
+BUG_REPORT_URL="https://bugs.centos.org/"
+
+CENTOS_MANTISBT_PROJECT="CentOS-7"
+CENTOS_MANTISBT_PROJECT_VERSION="7"
+REDHAT_SUPPORT_PRODUCT="centos"
+REDHAT_SUPPORT_PRODUCT_VERSION="7"
+
+CISCO_RELEASE_INFO=/etc/shared/os-release
+OS_RELEASE
+        end
+
+        let(:have_cisco_release) { true }
+
+        let(:cisco_release_content) do
+          <<-CISCO_RELEASE
+ID=nexus
+ID_LIKE=cisco-wrlinux
+NAME=Nexus
+VERSION="7.0(3)I2(0.455)"
+VERSION_ID="7.0(3)I2"
+CISCO_RELEASE
+        end
+
+        before do
+          expect(File).to receive(:read).with("/etc/redhat-release").and_return("CentOS release 7.1")
+          expect(File).to receive(:read).with("/etc/os-release").and_return(os_release_content)
+          expect(File).to receive(:read).with("/etc/shared/os-release").and_return(cisco_release_content)
+        end
+
+        it "correctly detects Nexus environment" do
+          @plugin.run
+          expect(@plugin[:platform]).to eq("nexus")
+          expect(@plugin[:platform_family]).to eq("rhel")
+          expect(@plugin[:platform_version]).to eq("7.0(3)I2(0.455)")
+        end
+      end
     end
 
   end
@@ -596,12 +650,13 @@ OS_RELEASE
 
     let(:have_os_release) { true }
 
-    it "should set platform to nexus and platform_family to wrlinux" do
+    it "should set platform to nexus and platform_family to cisco-wrlinux" do
       @plugin.lsb = nil
-      expect(File).to receive(:read).with("/etc/os-release").and_return("ID_LIKE=wrlinux\nID=nexus\nCISCO_RELEASE_INFO=/etc/os-release")
+      expect(File).to receive(:read).with("/etc/os-release").and_return("ID_LIKE=cisco-wrlinux\nID=nexus\nVERSION_ID=7.0(3)I2\nVERSION=7.0(3)I2(0.455)\nCISCO_RELEASE_INFO=/etc/os-release")
       @plugin.run
       expect(@plugin[:platform]).to eq("nexus")
-      expect(@plugin[:platform_family]).to eq("wrlinux")
+      expect(@plugin[:platform_family]).to eq("cisco-wrlinux")
+      expect(@plugin[:platform_version]).to eq("7.0(3)I2(0.455)")
     end
   end
 end


### PR DESCRIPTION
Add logic and tests to handle both native cisco-wrlinux and CentOS guestshell. Also avoid blindly trusting contents of os-release files as described in #572.