### PR TITLE
Additional Cisco WRL 7 and IOS-XR changes based on Cisco feedback

### DIFF
--- a/lib/ohai/plugins/linux/platform.rb
+++ b/lib/ohai/plugins/linux/platform.rb
@@ -143,13 +143,17 @@ Ohai.plugin(:Platform) do
       # kernel release will be used - ex. 3.13
       platform_version `uname -r`.strip
     elsif os_release_file_is_cisco?
-      raise "unknown Cisco /etc/os-release ID field" unless os_release_info['ID'] =~ /nexus|exr/i
-      raise "unknown Cisco /etc/os-release ID-LIKE field" unless os_release_info['ID_LIKE'].include?('wrlinux')
-      if os_release_info['ID'].include?('nexus')
+      raise 'unknown Cisco /etc/os-release ID-LIKE field' unless os_release_info['ID_LIKE'].include?('wrlinux')
+
+      case os_release_info['ID']
+      when 'nexus'
         platform 'nexus'
+      when 'ios_xr'
+        platform 'ios_xr'
       else
-        platform 'ios-xr'
+        raise 'unknown Cisco /etc/os-release ID field'
       end
+
       platform_family 'wrlinux'
       platform_version os_release_info['VERSION']
     elsif lsb[:id] =~ /RedHat/i

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -668,11 +668,11 @@ CISCO_RELEASE
 
     let(:have_os_release) { true }
 
-    it "should set platform to ios-xr and platform_family to wrlinux" do
+    it "should set platform to ios_xr and platform_family to wrlinux" do
       @plugin.lsb = nil
-      expect(File).to receive(:read).twice.with("/etc/os-release").and_return("ID=eXR\nID_LIKE=wrlinux\nNAME=IOS-XR\nVERSION=\"6.0.0.3I\"\nVERSION_ID=6.0.0.3I\nPRETTY_NAME=\"Cisco IOS XR Software, Version 6.0.0.03I\"\nHOME_URL=http://www.cisco.com\nBUILD_ID=TBD\nCISCO_RELEASE_INFO=/etc/os-release")
+      expect(File).to receive(:read).twice.with("/etc/os-release").and_return("ID=ios_xr\nID_LIKE=cisco-wrlinux\nNAME=IOS XR\nVERSION=\"6.0.0.3I\"\nVERSION_ID=6.0.0.3I\nPRETTY_NAME=\"Cisco IOS XR Software, Version 6.0.0.03I\"\nHOME_URL=http://www.cisco.com\nCISCO_RELEASE_INFO=/etc/os-release")
       @plugin.run
-      expect(@plugin[:platform]).to eq("ios-xr")
+      expect(@plugin[:platform]).to eq("ios_xr")
       expect(@plugin[:platform_family]).to eq("wrlinux")
       expect(@plugin[:platform_version]).to eq("6.0.0.3I")
     end

--- a/spec/unit/plugins/linux/platform_spec.rb
+++ b/spec/unit/plugins/linux/platform_spec.rb
@@ -670,7 +670,7 @@ CISCO_RELEASE
 
     it "should set platform to ios_xr and platform_family to wrlinux" do
       @plugin.lsb = nil
-      expect(File).to receive(:read).twice.with("/etc/os-release").and_return("ID=ios_xr\nID_LIKE=cisco-wrlinux\nNAME=IOS XR\nVERSION=\"6.0.0.3I\"\nVERSION_ID=6.0.0.3I\nPRETTY_NAME=\"Cisco IOS XR Software, Version 6.0.0.03I\"\nHOME_URL=http://www.cisco.com\nCISCO_RELEASE_INFO=/etc/os-release")
+      expect(File).to receive(:read).twice.with("/etc/os-release").and_return("ID=ios_xr\nID_LIKE=cisco-wrlinux\nNAME=\"IOS XR\"\nVERSION=\"6.0.0.3I\"\nVERSION_ID=6.0.0.3I\nPRETTY_NAME=\"Cisco IOS XR Software, Version 6.0.0.03I\"\nHOME_URL=http://www.cisco.com\nCISCO_RELEASE_INFO=/etc/os-release")
       @plugin.run
       expect(@plugin[:platform]).to eq("ios_xr")
       expect(@plugin[:platform_family]).to eq("wrlinux")


### PR DESCRIPTION
Additional Cisco WRL 7 and IOS-XR changes based on Cisco feedback in chef/ohai#617.

Cisco is changing the following:
 * ID: eXR => ios_xr (code changed)
 * ID_LIKE: wrlinux => cisco-wrlinux (code NOT changed, still matching only on 'wrlinux' as to not break WRL 5)
 * NAME: IOS-XR => IOS XR
 * BUILD_ID: (removed)